### PR TITLE
Lesson10 - Pypy tests

### DIFF
--- a/students/ghassan/lesson10/fib_recursive.py
+++ b/students/ghassan/lesson10/fib_recursive.py
@@ -1,0 +1,10 @@
+def recur_fibo(n):
+    """Recursive function to
+    print Fibonacci sequence"""
+    if n <= 1:
+        return n
+    else:
+        return recur_fibo(n-1) + recur_fibo(n-2)
+
+
+x = recur_fibo(40)

--- a/students/ghassan/lesson10/fib_recusrsive_results.txt
+++ b/students/ghassan/lesson10/fib_recusrsive_results.txt
@@ -1,0 +1,49 @@
+Pypy:
+	Command being timed: "python fib_recursive.py"
+	User time (seconds): 2.83
+	System time (seconds): 0.06
+	Percent of CPU this job got: 99%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.92
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 50268
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 14434
+	Voluntary context switches: 0
+	Involuntary context switches: 1581
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 0
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+Python3:
+	Command being timed: "python fib_recursive.py"
+	User time (seconds): 59.33
+	System time (seconds): 0.33
+	Percent of CPU this job got: 98%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:00.83
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 8412
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 2397
+	Voluntary context switches: 0
+	Involuntary context switches: 71350
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 0
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0

--- a/students/ghassan/lesson10/hash.py
+++ b/students/ghassan/lesson10/hash.py
@@ -1,0 +1,13 @@
+import hashlib
+
+text_from_iliad = """
+The armies approach each other, but before they meet, Paris offers to end the war by fighting a duel with Menelaus, 
+urged by his brother and head of the Trojan army, Hector. 
+While Helen tells Priam about the Greek commanders from the walls of Troy, 
+both sides swear a truce and promise to abide by the outcome of the duel. Paris is beaten, 
+but Aphrodite rescues him and leads him to bed with Helen before Menelaus can kill him.
+"""
+
+for i in range(10000000):
+    x = hashlib.sha224(text_from_iliad.encode()).hexdigest()
+

--- a/students/ghassan/lesson10/hash_results.txt
+++ b/students/ghassan/lesson10/hash_results.txt
@@ -1,0 +1,50 @@
+pypy:
+	Command being timed: "python pypy_test.py"
+	User time (seconds): 40.33
+	System time (seconds): 0.34
+	Percent of CPU this job got: 99%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:40.92
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 55272
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 14387
+	Voluntary context switches: 0
+	Involuntary context switches: 23787
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 0
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+
+
+Python3
+	Command being timed: "python pypy_test.py"
+	User time (seconds): 30.53
+	System time (seconds): 0.20
+	Percent of CPU this job got: 96%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:31.84
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 9132
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 2582
+	Voluntary context switches: 0
+	Involuntary context switches: 41936
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 0
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0


### PR DESCRIPTION
I picked pypy for this lesson, because we use it at work and it outperforms python3. The "tool" we use takes about 6 minutes in pypy, while it takes around 15 minutes in python.
For this lesson, I'm using:
1) hashing: Python outperformed pypy. I'm not sure why :)
2) Fibonacci series using recursion. Pypy outperforms python, by a lot!

I included the gtime results.