### PR TITLE
Lesson06, Advanced Testing, Instructor Feedback. 

### DIFF
--- a/students/toddschultz/session06/calculator/adder.py
+++ b/students/toddschultz/session06/calculator/adder.py
@@ -1,0 +1,8 @@
+'''Execute addition commands'''
+
+class Adder():
+    '''Adds two operands'''
+    
+    @staticmethod
+    def calc(operand_1, operand_2):
+        return operand_1 + operand_2

--- a/students/toddschultz/session06/calculator/adder.py
+++ b/students/toddschultz/session06/calculator/adder.py
@@ -1,8 +1,10 @@
 '''Execute addition commands'''
 
+
 class Adder():
     '''Adds two operands'''
-    
+
     @staticmethod
+    '''Static Method does the work'''
     def calc(operand_1, operand_2):
         return operand_1 + operand_2

--- a/students/toddschultz/session06/calculator/calculator.py
+++ b/students/toddschultz/session06/calculator/calculator.py
@@ -1,0 +1,35 @@
+from .exceptions import InsufficientOperands
+
+class Calculator(object):
+
+    def __init__(self, adder, subtracter, multiplier, divider):
+        self.adder = adder
+        self.subtracter = subtracter
+        self.multiplier = multiplier
+        self.divider = divider
+
+        self.stack = []
+
+    def enter_number(self, number):
+        self.stack.insert(1, number)
+
+    def _do_calc(self, operator):
+        try:
+            result = operator.calc(self.stack[0], self.stack[1])
+        except IndexError:
+            raise InsufficientOperands
+
+        self.stack = [result]
+        return result
+
+    def add(self):
+        return self._do_calc(self.adder)
+
+    def subtract(self):
+        return self._do_calc(self.subtracter)
+
+    def multiply(self):
+        return self._do_calc(self.multiplier)
+
+    def divide(self):
+        return self._do_calc(self.divider)

--- a/students/toddschultz/session06/calculator/calculator.py
+++ b/students/toddschultz/session06/calculator/calculator.py
@@ -1,4 +1,4 @@
-''' My Digital Calculator '''
+''' My Digital Calculator. '''
 
 from .exceptions import InsufficientOperands
 

--- a/students/toddschultz/session06/calculator/calculator.py
+++ b/students/toddschultz/session06/calculator/calculator.py
@@ -1,6 +1,6 @@
 ''' My Digital Calculator. '''
-
 from .exceptions import InsufficientOperands
+
 
 class Calculator():
     ''' Base class '''
@@ -19,7 +19,8 @@ class Calculator():
         self.stack.insert(1, number)
 
     def _do_calc(self, operator):
-        ''' Execute operations with the proper operator and catches InsufficientOperands '''
+        ''' Execute operations with the proper operator
+        and catches InsufficientOperands '''
         try:
             result = operator.calc(self.stack[0], self.stack[1])
         except IndexError:

--- a/students/toddschultz/session06/calculator/calculator.py
+++ b/students/toddschultz/session06/calculator/calculator.py
@@ -1,8 +1,12 @@
+''' My Digital Calculator '''
+
 from .exceptions import InsufficientOperands
 
-class Calculator(object):
+class Calculator():
+    ''' Base class '''
 
     def __init__(self, adder, subtracter, multiplier, divider):
+        ''' Initializer '''
         self.adder = adder
         self.subtracter = subtracter
         self.multiplier = multiplier
@@ -11,9 +15,11 @@ class Calculator(object):
         self.stack = []
 
     def enter_number(self, number):
+        ''' inserts a new number in the second position '''
         self.stack.insert(1, number)
 
     def _do_calc(self, operator):
+        ''' Execute operations with the proper operator and catches InsufficientOperands '''
         try:
             result = operator.calc(self.stack[0], self.stack[1])
         except IndexError:
@@ -23,13 +29,17 @@ class Calculator(object):
         return result
 
     def add(self):
+        ''' returns numbers added '''
         return self._do_calc(self.adder)
 
     def subtract(self):
+        ''' returns numbers subtracted '''
         return self._do_calc(self.subtracter)
 
     def multiply(self):
+        ''' returns numbers multiplied '''
         return self._do_calc(self.multiplier)
 
     def divide(self):
+        ''' returns numbers divided '''
         return self._do_calc(self.divider)

--- a/students/toddschultz/session06/calculator/divider.py
+++ b/students/toddschultz/session06/calculator/divider.py
@@ -1,8 +1,10 @@
 '''Execute division commands'''
 
+
 class Divider():
     '''Divides two operands'''
-    
+
     @staticmethod
+    '''Static Method does the work'''
     def calc(operand_1, operand_2):
         return operand_1/operand_2

--- a/students/toddschultz/session06/calculator/divider.py
+++ b/students/toddschultz/session06/calculator/divider.py
@@ -1,0 +1,8 @@
+'''Execute division commands'''
+
+class Divider():
+    '''Divides two operands'''
+    
+    @staticmethod
+    def calc(operand_1, operand_2):
+        return operand_1/operand_2

--- a/students/toddschultz/session06/calculator/exceptions.py
+++ b/students/toddschultz/session06/calculator/exceptions.py
@@ -1,0 +1,4 @@
+''' What to do when there is not enough operands '''
+class InsufficientOperands(Exception):
+    ''' Simply passes if there are not enough operands '''
+    pass

--- a/students/toddschultz/session06/calculator/exceptions.py
+++ b/students/toddschultz/session06/calculator/exceptions.py
@@ -1,4 +1,6 @@
 ''' What to do when there is not enough operands '''
+
+
 class InsufficientOperands(Exception):
     ''' Simply passes if there are not enough operands '''
     pass

--- a/students/toddschultz/session06/calculator/multiplier.py
+++ b/students/toddschultz/session06/calculator/multiplier.py
@@ -1,7 +1,9 @@
 '''Execute multiplication commands'''
+
+
 class Multiplier():
     '''Execute multiplication commands'''
-    
     @staticmethod
+    '''Static Method does the work'''
     def calc(operand_1, operand_2):
         return operand_1*operand_2

--- a/students/toddschultz/session06/calculator/multiplier.py
+++ b/students/toddschultz/session06/calculator/multiplier.py
@@ -1,0 +1,7 @@
+'''Execute multiplication commands'''
+class Multiplier():
+    '''Execute multiplication commands'''
+    
+    @staticmethod
+    def calc(operand_1, operand_2):
+        return operand_1*operand_2

--- a/students/toddschultz/session06/calculator/subtracter.py
+++ b/students/toddschultz/session06/calculator/subtracter.py
@@ -1,0 +1,8 @@
+'''Execute subtraction commands'''
+
+class Subtracter():
+    '''subtracts two opperands'''
+    
+    @staticmethod
+    def calc(operand_1, operand_2):
+        return operand_1 - operand_2

--- a/students/toddschultz/session06/calculator/subtracter.py
+++ b/students/toddschultz/session06/calculator/subtracter.py
@@ -1,8 +1,10 @@
 '''Execute subtraction commands'''
 
+
 class Subtracter():
     '''subtracts two opperands'''
-    
+
     @staticmethod
+    '''Static Method does the work'''
     def calc(operand_1, operand_2):
         return operand_1 - operand_2

--- a/students/toddschultz/session06/integration-test.py
+++ b/students/toddschultz/session06/integration-test.py
@@ -8,7 +8,6 @@ from calculator.divider import Divider
 from calculator.calculator import Calculator
 from calculator.exceptions import InsufficientOperands
 
-
 class ModuleTests(TestCase):
 
     def test_module(self):

--- a/students/toddschultz/session06/integration-test.py
+++ b/students/toddschultz/session06/integration-test.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from calculator.adder import Adder
+from calculator.subtracter import Subtracter
+from calculator.multiplier import Multiplier
+from calculator.divider import Divider
+from calculator.calculator import Calculator
+from calculator.exceptions import InsufficientOperands
+
+
+class ModuleTests(TestCase):
+
+    def test_module(self):
+
+        calculator = Calculator(Adder(), Subtracter(), Multiplier(), Divider())
+
+        calculator.enter_number(5)
+        calculator.enter_number(2)
+        
+        calculator.multiply()
+
+        calculator.enter_number(46)
+
+        calculator.add()
+
+        calculator.enter_number(8)
+
+        calculator.divide()
+
+        calculator.enter_number(1)
+
+        result = calculator.subtract()
+
+        self.assertEqual(6, result)

--- a/students/toddschultz/session06/unit-test.py
+++ b/students/toddschultz/session06/unit-test.py
@@ -1,0 +1,103 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+import logging
+
+from calculator.adder import Adder
+from calculator.subtracter import Subtracter
+from calculator.multiplier import Multiplier
+from calculator.divider import Divider
+from calculator.calculator import Calculator
+from calculator.exceptions import InsufficientOperands
+
+class DividerTests(TestCase):
+
+    def test_dividing(self):
+        divider = Divider()
+
+        for i in range(-10, 10):
+            for j in range(-10, 10):
+                try:
+                    self.assertEqual(i / j, divider.calc(i, j))
+                except ZeroDivisionError:
+                    logging.debug("Tried to divide by zero. Var i was {}. Recovered gracefully.".format(i))
+
+class MultiplierTests(TestCase):
+
+    def test_multiplying(self):
+        multiplier = Multiplier()
+
+        for i in range(-10, 10):
+            for j in range(-10, 10):
+                self.assertEqual(i * j, multiplier.calc(i, j))
+
+class AdderTests(TestCase):
+
+    def test_adding(self):
+        adder = Adder()
+
+        for i in range(-10, 10):
+            for j in range(-10, 10):
+                self.assertEqual(i + j, adder.calc(i, j))
+
+
+class SubtracterTests(TestCase):
+
+    def test_subtracting(self):
+        subtracter = Subtracter()
+
+        for i in range(-10, 10):
+            for j in range(-10, 10):
+                self.assertEqual(i - j, subtracter.calc(i, j))
+
+
+class CalculatorTests(TestCase):
+
+    def setUp(self):
+        self.adder = Adder()
+        self.subtracter = Subtracter()
+        self.multiplier = Multiplier()
+        self.divider = Divider()
+
+        self.calculator = Calculator(self.adder, self.subtracter, self.multiplier, self.divider)
+
+    def test_insufficient_operands(self):
+        self.calculator.enter_number(0)
+
+        with self.assertRaises(InsufficientOperands):
+            self.calculator.add()
+
+    def test_adder_call(self):
+        self.adder.calc = MagicMock(return_value=0)
+
+        self.calculator.enter_number(1)
+        self.calculator.enter_number(2)
+        self.calculator.add()
+
+        self.adder.calc.assert_called_with(2, 1)
+
+    def test_subtracter_call(self):
+        self.subtracter.calc = MagicMock(return_value=0)
+
+        self.calculator.enter_number(1)
+        self.calculator.enter_number(2)
+        self.calculator.subtract()
+
+        self.subtracter.calc.assert_called_with(2, 1)
+
+    def test_multiplier_call(self):
+        self.multiplier.calc = MagicMock(return_value=0)
+
+        self.calculator.enter_number(1)
+        self.calculator.enter_number(2)
+        self.calculator.multiply()
+
+        self.multiplier.calc.assert_called_with(2, 1)
+
+    def test_divider_call(self):
+        self.divider.calc = MagicMock(return_value=0)
+
+        self.calculator.enter_number(1)
+        self.calculator.enter_number(2)
+        self.calculator.divide()
+
+        self.divider.calc.assert_called_with(2, 1)

--- a/students/toddschultz/session06/unit-test.py
+++ b/students/toddschultz/session06/unit-test.py
@@ -17,7 +17,7 @@ class DividerTests(TestCase):
         for i in range(-10, 10):
             for j in range(-10, 10):
                 try:
-                    self.assertEqual(i / j, divider.calc(i, j))
+                    self.assertEqual(j / i, divider.calc(i, j))
                 except ZeroDivisionError:
                     logging.debug("Tried to divide by zero. Var i was {}. Recovered gracefully.".format(i))
 

--- a/students/toddschultz/session06/unit-test.py
+++ b/students/toddschultz/session06/unit-test.py
@@ -9,6 +9,7 @@ from calculator.divider import Divider
 from calculator.calculator import Calculator
 from calculator.exceptions import InsufficientOperands
 
+
 class DividerTests(TestCase):
 
     def test_dividing(self):

--- a/students/toddschultz/session06/unit-test.py
+++ b/students/toddschultz/session06/unit-test.py
@@ -17,7 +17,7 @@ class DividerTests(TestCase):
         for i in range(-10, 10):
             for j in range(-10, 10):
                 try:
-                    self.assertEqual(j / i, divider.calc(i, j))
+                    self.assertEqual(i / j, divider.calc(i, j))
                 except ZeroDivisionError:
                     logging.debug("Tried to divide by zero. Var i was {}. Recovered gracefully.".format(i))
 
@@ -73,7 +73,7 @@ class CalculatorTests(TestCase):
         self.calculator.enter_number(2)
         self.calculator.add()
 
-        self.adder.calc.assert_called_with(2, 1)
+        self.adder.calc.assert_called_with(1, 2)
 
     def test_subtracter_call(self):
         self.subtracter.calc = MagicMock(return_value=0)
@@ -82,7 +82,7 @@ class CalculatorTests(TestCase):
         self.calculator.enter_number(2)
         self.calculator.subtract()
 
-        self.subtracter.calc.assert_called_with(2, 1)
+        self.subtracter.calc.assert_called_with(1, 2)
 
     def test_multiplier_call(self):
         self.multiplier.calc = MagicMock(return_value=0)
@@ -91,7 +91,7 @@ class CalculatorTests(TestCase):
         self.calculator.enter_number(2)
         self.calculator.multiply()
 
-        self.multiplier.calc.assert_called_with(2, 1)
+        self.multiplier.calc.assert_called_with(1, 2)
 
     def test_divider_call(self):
         self.divider.calc = MagicMock(return_value=0)
@@ -100,4 +100,4 @@ class CalculatorTests(TestCase):
         self.calculator.enter_number(2)
         self.calculator.divide()
 
-        self.divider.calc.assert_called_with(2, 1)
+        self.divider.calc.assert_called_with(1, 2)


### PR DESCRIPTION
My apologies for overlooking the Flake8 requirement, should be good now. 

WRT to pylint: If I add a Docstring to a @staticmethod I get ‘invalid syntax’. However if I remove the Docstring then I get ‘Missing method docstring’ and ‘Too few public methods’. I know I can add either error to .pylintrc and it works just fine, but those don’t seem like errors that you would want to ignore. 

So, currently pylint and flake8 report clear for me, with the above noted .pylintrc additions:

disable=unnecessary-pass,
	syntax-error,