### PR TITLE
Lesson09

### DIFF
--- a/students/smitco/lesson09/threaded_async.py
+++ b/students/smitco/lesson09/threaded_async.py
@@ -1,0 +1,71 @@
+# lesson 09 threaded downloader exercise
+# !/usr/bin/env python3
+
+# async version copied from course video
+# took 4 seconds on my machine 
+
+import time
+import asyncio
+import aiohttp
+import requests
+
+WORD = 'trump'
+NEWS_API_KEY = "36f7da631b8a4373a98bcae0f0516d7f"
+
+base_url = 'https://newsapi.org/v1/'
+
+async def get_sources(sources):
+    """ Get the english language sources of news """
+    
+    url = base_url + 'sources'
+    params = {'langauge': 'en'}
+    session = aiohttp.ClientSession()
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, ssl=False, params=params) as resp:
+            data = await resp.json()
+            print('Got the sources')
+    sources.extend([src['id'].strip() for src in data['sources']])
+
+
+async def get_articles(source):
+    url = base_url + 'articles'
+    params = {'source': source,
+               'apiKey': NEWS_API_KEY,
+               'sortBy': 'top'
+             }
+    print('requesting:', source)
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, ssl=False, params=params) as resp:
+            if resp.status != 200:
+                print('something went wrong with: {}'.format(source))
+                await asyncio.sleep(0)
+                return
+            data = await resp.json()
+            print('got the articles from {}'.format(source))
+    titles.extend([str(art['title']) + str(art['description'])
+              for art in data['articles']])
+
+def count_word(word, titles):
+    word = word.lower()
+    count = 0
+    for title in titles:
+        if word in title.lower():
+            count += 1
+    return count
+
+start = time.time()
+
+loop = asyncio.get_event_loop()
+sources = []
+titles = []
+
+loop.run_until_complete(get_sources(sources))
+jobs = asyncio.gather(*(get_articles(source) for source in sources))
+loop.run_until_complete(jobs)
+loop.close()
+
+art_count = len(titles)
+word_count = count_word(WORD, titles) 
+
+print(WORD, 'found {} times in {} articles'.format(word_count, art_count))
+print('Process took {:.0f} seconds'.format(time.time() - start))

--- a/students/smitco/lesson09/threaded_multi.py
+++ b/students/smitco/lesson09/threaded_multi.py
@@ -1,0 +1,80 @@
+# lesson 09 threaded downloader exercise
+# !/usr/bin/env python3
+
+# ran out of requests from news api (250 available every 6 hours)
+# took 1 sec on my machine compared to 34 secs with sync and 4 secs with async
+
+import time
+import requests
+import threading
+import queue
+
+WORD = 'trump'
+NEWS_API_KEY = "36f7da631b8a4373a98bcae0f0516d7f"
+base_url = 'https://newsapi.org/v1/'
+
+sources = queue.Queue()
+
+def get_sources(s):
+    """ Get the english language sources of news """
+    
+    url = base_url + 'sources'
+    params = {'langauge': 'en'}
+    resp = requests.get(url, params=params)
+    data = resp.json()
+    s.put([(src['id'].strip()) for src in data['sources']])
+    print('all the sources')
+    return s
+    
+
+def get_articles(s):
+    while s.empty() != True:
+        source = s.get()
+        url = base_url + 'articles'
+        params = {'source': source,
+                   'apiKey': NEWS_API_KEY,
+                   'sortBy': 'top'
+                  }
+        print('requesting:', source)
+        resp = requests.get(url, params=params)
+        if resp.status_code != 200:
+            print('something went wrong with {}'.format(source))
+            print(resp)
+            print(resp.text)
+            s.task_done()
+            return
+        data = resp.json()
+        threading.Lock.acquire()
+        titles = [str(art['title']) + str(art['description'])
+                  for art in data['articles']]
+        threading.Lock.release()
+        s.task_done()
+        return titles
+
+
+def count_word(word, titles):
+    word = word.lower()
+    count = 0
+    for title in titles:
+        if word in title.lower():
+            count += 1
+    return count
+
+start = time.time()
+titles = []
+
+get_sources(sources)
+
+threads = []
+for i in range(1):
+    thread = threading.Thread(target=get_articles, args=(sources,))
+    threads.append(thread)
+    thread.start()
+
+sources.join()
+
+art_count = len(titles)
+word_count = count_word(WORD, titles)
+
+print(WORD, 'found {} times in {} articles'.format(word_count, art_count))
+print('Process took {:.0f} seconds'.format(time.time() - start))

--- a/students/smitco/lesson09/threaded_multi.py
+++ b/students/smitco/lesson09/threaded_multi.py
@@ -66,7 +66,7 @@ titles = []
 get_sources(sources)
 
 threads = []
-for i in range(1):
+for i in range(100):
     thread = threading.Thread(target=get_articles, args=(sources,))
     threads.append(thread)
     thread.start()

--- a/students/smitco/lesson09/threaded_sync.py
+++ b/students/smitco/lesson09/threaded_sync.py
@@ -1,0 +1,64 @@
+# lesson 09 threaded downloader exercise
+# !/usr/bin/env python3
+
+# sync version copied from course video
+# took 34 seconds on my machine
+
+import time
+import requests
+
+WORD = 'trump'
+NEWS_API_KEY = "36f7da631b8a4373a98bcae0f0516d7f"
+
+base_url = 'https://newsapi.org/v1/'
+
+def get_sources():
+    """ Get the english language sources of news """
+    
+    url = base_url + 'sources'
+    params = {'langauge': 'en'}
+    resp = requests.get(url, params=params)
+    data = resp.json()
+    sources = [src['id'].strip() for src in data['sources']]
+    print('all the sources')
+    print(sources)
+    return sources
+
+def get_articles(source):
+    url = base_url + 'articles'
+    params = {'source': source,
+               'apiKey': NEWS_API_KEY,
+               'sortBy': 'top'
+              }
+    print('requesting:', source)
+    resp = requests.get(url, params=params)
+    if resp.status_code != 200:
+        print('something went wrong with {}'.format(source))
+        print(resp)
+        print(resp.text)
+        return []
+    data = resp.json()
+    titles = [str(art['title']) + str(art['description'])
+              for art in data['articles']]
+    return titles
+
+def count_word(word, titles):
+    word = word.lower()
+    count = 0
+    for title in titles:
+        if word in title.lower():
+            count += 1
+    return count
+
+start = time.time()
+sources = get_sources()
+
+art_count = 0
+word_count = 0
+for source in sources:
+    titles = get_articles(source)
+    art_count += len(titles)
+    word_count += count_word(WORD, titles)
+
+print(WORD, 'found {} times in {} articles'.format(word_count, art_count))
+print('Process took {:.0f} seconds'.format(time.time() - start))


### PR DESCRIPTION
I ran out of available requests from news api (250 in 6 hours), but it runs to the print statements at the end. I am running out of time in the class and wanted to have something turned in. When I have more requests, I will rerun the code to double check.

My output:
(pythree) C:\Users\ckastner\UW\Course 2\lesson09>python threaded_multi.py
all the sources
requesting: ['abc-news-au', 'al-jazeera-english', 'ars-technica', 'associated-press', 'bbc-news', 'bbc-sport', 'bild', 'bloomberg', 'breitbart-news', 'business-insider', 'business-insider-uk', 'buzzfeed', 'cnbc', 'cnn', 'daily-mail', 'der-tagesspiegel', 'die-zeit', 'engadget', 'entertainment-weekly', 'espn', 'espn-cric-info', 'financial-times', 'focus', 'football-italia', 'fortune', 'four-four-two', 'fox-sports', 'google-news', 'gruenderszene', 'hacker-news', 'handelsblatt', 'ign', 'independent', 'mashable', 'metro', 'mirror', 'mtv-news', 'mtv-news-uk', 'national-geographic', 'new-scientist', 'newsweek', 'new-york-magazine', 'nfl-news', 'polygon', 'recode', 'reddit-r-all', 'reuters', 'spiegel-online', 't3n', 'talksport', 'techcrunch', 'techradar', 'the-economist', 'the-guardian-au', 'the-guardian-uk', 'the-hindu', 'the-huffington-post', 'the-lad-bible', 'the-new-york-times', 'the-next-web', 'the-sport-bible', 'the-telegraph', 'the-times-of-india', 'the-verge', 'the-wall-street-journal', 'the-washington-post', 'time', 'usa-today', 'wired-de', 'wirtschafts-woche']
something went wrong with ['abc-news-au', 'al-jazeera-english', 'ars-technica', 'associated-press', 'bbc-news', 'bbc-sport', 'bild', 'bloomberg', 'breitbart-news', 'business-insider', 'business-insider-uk', 'buzzfeed', 'cnbc', 'cnn', 'daily-mail', 'der-tagesspiegel', 'die-zeit', 'engadget', 'entertainment-weekly', 'espn', 'espn-cric-info', 'financial-times', 'focus', 'football-italia', 'fortune', 'four-four-two', 'fox-sports', 'google-news', 'gruenderszene', 'hacker-news', 'handelsblatt', 'ign', 'independent', 'mashable', 'metro', 'mirror', 'mtv-news', 'mtv-news-uk', 'national-geographic', 'new-scientist', 'newsweek', 'new-york-magazine', 'nfl-news', 'polygon', 'recode', 'reddit-r-all', 'reuters', 'spiegel-online', 't3n', 'talksport', 'techcrunch', 'techradar', 'the-economist', 'the-guardian-au', 'the-guardian-uk', 'the-hindu', 'the-huffington-post', 'the-lad-bible', 'the-new-york-times', 'the-next-web', 'the-sport-bible', 'the-telegraph', 'the-times-of-india', 'the-verge', 'the-wall-street-journal', 'the-washington-post', 'time', 'usa-today', 'wired-de', 'wirtschafts-woche']
<Response [429]>
{"status":"error","code":"rateLimited","message":"You have made too many requests recently. Developer accounts are limited to 1,000 requests over a 24 hour period (250 requests available every 6 hours). Please upgrade to a paid plan if you need more requests."}
trump found 0 times in 0 articles
Process took 1 seconds